### PR TITLE
Catch errors in map function

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,8 +16,12 @@ function ctor(options, fn) {
 
   var Map = through2.ctor(options, function (chunk, encoding, callback) {
     if (this.options.wantStrings) chunk = chunk.toString()
-    this.push(fn.call(this, chunk, this._index++))
-    return callback()
+    try {
+      this.push(fn.call(this, chunk, this._index++))
+      return callback()
+    } catch (e) {
+      return callback(e)
+    }
   })
   Map.prototype._index = 0
   return Map

--- a/test/index.js
+++ b/test/index.js
@@ -196,3 +196,29 @@ test("end early", function (t) {
   ]).pipe(f)
     .pipe(concat({objectMode: true}, combine))
 })
+
+test("error", function (t) {
+  t.plan(1)
+
+  var f = map(function (chunk) {
+    throw new Error("Error in map function")
+  })
+
+  function end () {
+    t.fail("Should not end")
+  }
+
+  var r = spigot([
+    "a",
+    "b",
+    "cdefghijk",
+    "lmnopqrst",
+    "u",
+    "vwxyz",
+  ]).pipe(f)
+    .on("end", end)
+    .on("error", function (err) {
+      t.true(err instanceof Error, "Caught error")
+    })
+})
+


### PR DESCRIPTION
Any error thrown in the map function will emit an 'error' event on the stream, as expected.
